### PR TITLE
Add keybindings to adjust brightness

### DIFF
--- a/i3/.config/i3/config
+++ b/i3/.config/i3/config
@@ -59,6 +59,10 @@ bindsym XF86AudioLowerVolume exec --no-startup-id pactl set-sink-volume @DEFAULT
 bindsym XF86AudioMute exec --no-startup-id pactl set-sink-mute @DEFAULT_SINK@ toggle && $refresh_i3status
 bindsym XF86AudioMicMute exec --no-startup-id pactl set-source-mute @DEFAULT_SOURCE@ toggle && $refresh_i3status
 
+# Use https://github.com/Hummer12007/brightnessctl | brightnessctl | to adjust brightness
+bindsym XF86MonBrightnessDown exec --no-startup-id brightnessctl --min-val=2 -q set 3%-
+bindsym XF86MonBrightnessUp exec --no-startup-id brightnessctl -q set 3%+
+
 # use these keys for focus, movement, and resize directions when reaching for
 # the arrows is not convenient
 set $up l


### PR DESCRIPTION
brightness keys on laptop weren't working properly
added keybindings to **adjust brightness**

steps:
1. add current user to _video_ group: `sudo usermod -aG video $USER`
2. open `xev` program to _verify_ the _key names_
3. reload i3: Mod-Shift-R or Mod-Shift-E to logout (if reload doesn't work)