### PR TITLE
gnome prtscrn keybind for i3

### DIFF
--- a/i3/.config/i3/config
+++ b/i3/.config/i3/config
@@ -277,3 +277,10 @@ client.unfocused         $overlay0 $base $text  $rosewater $overlay0
 client.urgent            $peach    $base $peach $overlay0  $peach
 client.placeholder       $overlay0 $base $text  $overlay0  $overlay0
 client.background        $base
+
+
+# Custom config down here
+#interactive screenshot by pressing printscreen
+bindsym Print exec gnome-screenshot -i
+#crop-area screenshot by pressing Mod + printscreen
+bindsym $mod+Print exec gnome-screenshot -a


### PR DESCRIPTION
supersedes #43 