### PR TITLE
Add battery widget

### DIFF
--- a/awesome/.config/awesome/rc.lua
+++ b/awesome/.config/awesome/rc.lua
@@ -22,6 +22,10 @@ require("awful.hotkeys_popup.keys")
 local debian = require("debian.menu")
 local has_fdo, freedesktop = pcall(require, "freedesktop")
 
+-- battery widget
+local battery_widget = require("battery-widget")
+
+
 -- {{{ Error handling
 -- Check if awesome encountered an error during startup and fell back to
 -- another config (This code will only ever execute for the fallback config)
@@ -213,7 +217,7 @@ awful.screen.connect_for_each_screen(function(s)
     }
 
     -- Create the wibox
-    s.mywibox = awful.wibar({ position = "top", screen = s })
+    s.mywibox = awful.wibar({ position = "top", screen = s, })
 
     -- Add widgets to the wibox
     s.mywibox:setup {
@@ -231,6 +235,12 @@ awful.screen.connect_for_each_screen(function(s)
             wibox.widget.systray(),
             mytextclock,
             s.mylayoutbox,
+            battery_widget {
+                ac = "ac",
+                ac_prefix = "🔌",
+                alert_title = "Low battery !",
+                alert_text = "${AC_BAT}${time_est}",
+            },
         },
     }
 end)


### PR DESCRIPTION
**github.com/deficient/battery-widget**
steps:

1. git clone into .config/awesome
2. add battery widget to wibox to reflect battery life on laptop

Full list of _options_:
```
battery_widget {
    ac = "AC",
    adapter = "BAT0",
    ac_prefix = "AC: ",
    battery_prefix = "Bat: ",
    percent_colors = {
        { 25, "red"   },
        { 50, "orange"},
        {999, "green" },
    },
    listen = true,
    timeout = 10,
    widget_text = "${AC_BAT}${color_on}${percent}%${color_off}",
    widget_font = "Deja Vu Sans Mono 16",
    tooltip_text = "Battery ${state}${time_est}\nCapacity: ${capacity_percent}%",
    alert_threshold = 5,
    alert_timeout = 0,
    alert_title = "Low battery !",
    alert_text = "${AC_BAT}${time_est}",
    alert_icon = "~/Downloads/low_battery_icon.png",
    warn_full_battery = true,
    full_battery_icon = "~/Downloads/full_battery_icon.png",
} 